### PR TITLE
Add 80s TV channel section

### DIFF
--- a/assets/tv-player.js
+++ b/assets/tv-player.js
@@ -1,0 +1,58 @@
+class EightiesTV extends HTMLElement {
+  connectedCallback() {
+    this.staticVideo = this.querySelector('.tv-static');
+    this.channels = Array.from(this.querySelectorAll('.tv-channel'));
+    this.index = 0;
+
+    this.prevButton = this.querySelector('.tv-control--prev');
+    this.nextButton = this.querySelector('.tv-control--next');
+
+    this.prevButton?.addEventListener('click', () => this.changeChannel(this.index - 1));
+    this.nextButton?.addEventListener('click', () => this.changeChannel(this.index + 1));
+
+    this.channels.forEach((video) => {
+      video.addEventListener('ended', () => this.changeChannel(this.index + 1));
+      video.autoplay = true;
+      video.muted = true;
+      video.playsInline = true;
+    });
+
+    this.showChannel(0);
+  }
+
+  showStatic(show) {
+    if (!this.staticVideo) return;
+    if (show) {
+      this.setAttribute('data-show-static', '');
+      this.staticVideo.currentTime = 0;
+      this.staticVideo.play();
+    } else {
+      this.removeAttribute('data-show-static');
+      this.staticVideo.pause();
+    }
+  }
+
+  showChannel(index) {
+    this.channels.forEach((video, i) => {
+      video.classList.toggle('active', i === index);
+      if (i === index) {
+        video.currentTime = 0;
+        video.play();
+      } else {
+        video.pause();
+      }
+    });
+    this.index = index;
+  }
+
+  changeChannel(newIndex) {
+    newIndex = (newIndex + this.channels.length) % this.channels.length;
+    this.showStatic(true);
+    setTimeout(() => {
+      this.showStatic(false);
+      this.showChannel(newIndex);
+    }, 500);
+  }
+}
+
+customElements.define('eighties-tv-component', EightiesTV);

--- a/blocks/_tv-channel.liquid
+++ b/blocks/_tv-channel.liquid
@@ -1,0 +1,34 @@
+{% if block.settings.video != blank %}
+  <video
+    class="tv-channel"
+    muted
+    playsinline
+    data-channel
+    preload="auto"
+  >
+    {%- for source in block.settings.video.sources -%}
+      <source src="{{ source.url }}" type="{{ source.mime_type }}">
+    {%- endfor -%}
+  </video>
+{% else %}
+  <div class="tv-channel placeholder">
+    <placeholder-image data-block-id="{{ section.id }}-{{ block.id }}" data-type="video"></placeholder-image>
+  </div>
+{% endif %}
+
+{% schema %}
+{
+  "name": "TV Channel",
+  "tag": null,
+  "settings": [
+    {
+      "type": "video",
+      "id": "video",
+      "label": "Video"
+    }
+  ],
+  "presets": [
+    {"name": "TV Channel"}
+  ]
+}
+{% endschema %}

--- a/sections/eighties-tv.liquid
+++ b/sections/eighties-tv.liquid
@@ -1,0 +1,110 @@
+{% stylesheet %}
+  .eighties-tv {
+    position: relative;
+    width: 100%;
+    max-width: 600px;
+    margin-inline: auto;
+  }
+
+  .eighties-tv__screen {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: 56.25%;
+    overflow: hidden;
+  }
+
+  .eighties-tv__screen video {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: none;
+  }
+
+  .eighties-tv__screen video.active {
+    display: block;
+  }
+
+  .eighties-tv[data-show-static] .tv-static {
+    display: block;
+  }
+
+  .tv-static {
+    display: none;
+  }
+
+  .eighties-tv__frame {
+    display: block;
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+  }
+
+  .eighties-tv__controls {
+    position: absolute;
+    bottom: 10px;
+    right: 10px;
+    z-index: 2;
+    display: flex;
+    gap: 4px;
+  }
+{% endstylesheet %}
+
+<script src="{{ 'tv-player.js' | asset_url }}" type="module"></script>
+
+<eighties-tv-component class="eighties-tv" section-id="{{ section.id }}">
+  <div class="eighties-tv__screen">
+    {% if section.settings.static_video != blank %}
+      <video class="tv-static" muted loop playsinline>
+        {%- for source in section.settings.static_video.sources -%}
+          <source src="{{ source.url }}" type="{{ source.mime_type }}">
+        {%- endfor -%}
+      </video>
+    {% endif %}
+
+    {% for block in section.blocks %}
+      {% if block.type == 'tv_channel' %}
+        {% render block %}
+      {% endif %}
+    {% endfor %}
+  </div>
+
+  {% if section.settings.tv_frame != blank %}
+    {{ section.settings.tv_frame | image_url: width: 900 | image_tag: class: 'eighties-tv__frame' }}
+  {% endif %}
+
+  <div class="eighties-tv__controls">
+    <button type="button" class="tv-control tv-control--prev">&#9664;</button>
+    <button type="button" class="tv-control tv-control--next">&#9654;</button>
+  </div>
+</eighties-tv-component>
+
+{% schema %}
+{
+  "name": "80s TV",
+  "tag": "section",
+  "class": "section-wrapper",
+  "blocks": [
+    {"type": "tv_channel"}
+  ],
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "tv_frame",
+      "label": "TV Frame (SVG)"
+    },
+    {
+      "type": "video",
+      "id": "static_video",
+      "label": "Static Video"
+    }
+  ],
+  "presets": [
+    {"name": "80s TV"}
+  ]
+}
+{% endschema %}


### PR DESCRIPTION
## Summary
- create `tv-player.js` for 80s TV logic
- add `_tv-channel.liquid` block to store TV videos
- add `eighties-tv.liquid` section that uses uploaded TV frame SVG, static video, and channel blocks

## Testing
- `git status --short`